### PR TITLE
Update Olympics homepage copy

### DIFF
--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -1,32 +1,45 @@
 <template>
   <div class="max-w-3xl mx-auto mt-6 px-4">
     <TimeLeft :startDate="new Date('2026-02-11T17:40:00')" />
-    <div class="mt-6 bg-white rounded-md p-6 space-y-4">
-      <h1 class="text-2xl font-bold text-gray-800">Laipni lūdzam prognožu spēlē!</h1>
-      <p class="text-gray-700">
-        Šī spēle ir lieliska iespēja pārbaudīt savas hokeja zināšanas un piedalīties aizraujošā
-        izaicinājumā. Tava galvenā misija ir prognozēt spēļu rezultātus — precīzi norādot, kura komanda
-        uzvarēs un cik daudz vārtu tiks gūti.
-      </p>
-      <h2 class="text-xl font-semibold text-blue-600">Kā tas darbojas?</h2>
-      <ol class="list-decimal list-inside text-gray-700 space-y-1">
-        <li>Norādi savu prognozi par komandas uzvaru un iespējamo rezultātu.</li>
-        <li>Seko līdzi spēles norisei un redzi, vai tava prognoze bija pareiza.</li>
-        <li>Saņem punktus par pareizi uzminētiem rezultātiem un seko līdzi savai pozīcijai tabulā.</li>
-      </ol>
-      <div class="bg-yellow-100 border-l-4 border-yellow-500 p-4 rounded">
-        <h3 class="font-semibold text-yellow-700">Svarīga piezīme:</h3>
-        <p class="text-gray-700 mt-1">
-          Tikai pamatlaika rezultāts tiks ņemts vērā, prognozējot uzvarētāju un rezultātu.
-          Tāpēc ir iespējams arī neizšķirts kā rezultāts!
+    <div class="mt-6 bg-white rounded-md p-6 space-y-5">
+      <div class="space-y-2">
+        <span
+          class="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-sm font-semibold text-blue-700"
+        >
+          Ziemas olimpiskās spēles — hokejs
+        </span>
+        <h1 class="text-2xl font-bold text-gray-900">Prognožu spēle ar olimpisko garu</h1>
+        <p class="text-gray-700">
+          Ienāc profesionālā prognožu vidē, kur hokeja rezultātu paredzēšana kļūst par stratēģisku
+          izaicinājumu. Tava misija ir precīzi prognozēt spēļu iznākumus un vārtu skaitu pamatlaikā.
         </p>
       </div>
-      <h2 class="text-xl font-semibold text-blue-600">Kāpēc piedalīties?</h2>
-      <ul class="list-disc list-inside text-gray-700 space-y-1">
-        <li>Pārbaudi un uzlabo savas hokeja zināšanas.</li>
-        <li>Sacensties ar citiem spēlētājiem un kļūsti par labāko prognozētāju.</li>
-        <li>Vienkāršs un aizraujošs spēles formāts, kas sniedz gan izklaidi, gan iespēju mācīties.</li>
-      </ul>
+
+      <div class="border-t border-gray-200 pt-4">
+        <h2 class="text-lg font-semibold text-gray-900">Kā darbojas prognozes</h2>
+        <ol class="mt-2 list-decimal list-inside text-gray-700 space-y-1">
+          <li>Ievadi uzvarētāju un sagaidāmo pamatlaika rezultātu.</li>
+          <li>Prognozes tiek salīdzinātas ar spēles pamatlaika iznākumu.</li>
+          <li>Punkti tiek piešķirti par precīzu rezultātu un pareizu uzvarētāju.</li>
+        </ol>
+      </div>
+
+      <div class="rounded-md border border-amber-200 bg-amber-50 p-4">
+        <h3 class="font-semibold text-amber-800">Svarīga informācija</h3>
+        <p class="text-gray-700 mt-1">
+          Vērā tiek ņemts tikai pamatlaika rezultāts. Tas nozīmē, ka neizšķirts ir derīgs prognozes
+          iznākums.
+        </p>
+      </div>
+
+      <div class="border-t border-gray-200 pt-4">
+        <h2 class="text-lg font-semibold text-gray-900">Kāpēc piedalīties</h2>
+        <ul class="mt-2 list-disc list-inside text-gray-700 space-y-1">
+          <li>Attīsti spēju analizēt komandu sniegumu olimpiskajā līmenī.</li>
+          <li>Seko līdzi turnīra gaitai un salīdzini sevi ar citiem prognozētājiem.</li>
+          <li>Baudi konkurenci un izklaidi vienlaikus.</li>
+        </ul>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
### Motivation
- Refresh the homepage messaging to present a more professional, Winter Olympics–focused hockey prediction experience.
- Improve content hierarchy and visual callouts so rules and benefits are clearer to users.

### Description
- Replace and reorganize the copy in `frontend/src/views/HomePage.vue` to use Olympics-themed headings, a prominence badge, and clearer sectioning.
- Adjust spacing and utility classes for improved readability while keeping the same `TimeLeft` component and no behavioral changes.
- This change is content-only and does not modify application logic or back-end code.

### Testing
- Ran `npm install` in `frontend` which completed successfully.
- Launched the dev server with `npm run dev` and Vite reported as ready.
- Rendered the homepage and captured a screenshot via Playwright which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f26d99188323ba300520a607989f)